### PR TITLE
Chore: Remove Vercel Analytics

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -24,7 +24,6 @@ const hostedSiteUrl = "https://www.the-frontview.dev/";
 const config = defineConfig({
   output: "server",
   adapter: vercel({
-    analytics: true,
     functionPerRoute: false, // Has to be set to false because more than 12 functions would be generated otherwise, which exceeds the Vercel limit
   }),
   site: hostedSiteUrl,
@@ -59,7 +58,6 @@ const config = defineConfig({
     sitemap({
       // Include the RSS feed page URL as it must appear, without the trailing slash
       customPages: [`${hostedSiteUrl}rss.xml`],
-      // Exclude the demo blog post page, as it should not be exposed
       filter: (page) =>
         ![
           // Exclude the demo blog post page, as it should not be exposed

--- a/src/pages/privacy.astro
+++ b/src/pages/privacy.astro
@@ -19,14 +19,12 @@ export const prerender = true;
       >
         Plausible Analytics
       </ExternalLink>
-       and <ExternalLink href="https://vercel.com/analytics" classString="mr-1">
-        Vercel Analytics
-      </ExternalLink>
-       to collect tracking data. These tools are GDPR, CCPA and cookie law
-      compliant and will not collect any personal data. The purpose of the
-      analytics is to show general information about the usage of the website,
-      like popular posts, commonly used devices from which site access took
-      place or countries from which site access took place.
+       to collect tracking data. This tool is GDPR, CCPA and cookie law
+      compliant and will not collect any personal data. Since it is also
+      self-hosted on a server in Frankfurt, Germany, no data will leave the EU.
+      The purpose of the analytics is to show general information about the
+      usage of the website, like popular posts, commonly used devices from which
+      site access took place or countries from which site access took place.
     </p>
   </div>
 </Layout>


### PR DESCRIPTION
* Chore: Remove Vercel Analytics

The usage limits of the service are exceeded too quickly, so there is no value in running it alongside Plausible.